### PR TITLE
fixed issue with workspace members using bare keys containing a period "."

### DIFF
--- a/src/scriptsTree.ts
+++ b/src/scriptsTree.ts
@@ -6,6 +6,8 @@ import tomlParser from 'toml'
 import fg from 'fast-glob'
 import { join } from 'path'
 
+const unqoutedKeyRegex = /(^\w+|^\w+-\w+|^\w+_\w+)\.(\w+)/gm
+
 export class CargoScriptsTree implements vscode.TreeDataProvider<ScriptTreeItem | WorkspaceTreeItem> {
   private readonly _onChangeTreeData = new vscode.EventEmitter<ScriptTreeItem | undefined>()
   public readonly onDidChangeTreeData = this._onChangeTreeData.event
@@ -68,7 +70,8 @@ export class CargoScriptsTree implements vscode.TreeDataProvider<ScriptTreeItem 
     this.valid = []
     this.folders.forEach(folder => {
       if (pathExists(folder)) {
-        const text = fs.readFileSync(folder, 'utf-8')
+        let text = fs.readFileSync(folder, 'utf-8')
+        text = text.replaceAll(unqoutedKeyRegex, "\"$1.$2\"")
         const toml = tomlParser.parse(text)
         const scripts = toml?.package?.metadata?.scripts
         const workspqceScripts = toml?.workspace?.metadata?.scripts


### PR DESCRIPTION
I was able to debug the extension and find the issue. 
The exception is being thrown from the TOML package and not from the extension.

When using a workspace and and a workspace member references a value from the workspace's Cargo.toml the key naming convention is {key}.workspace = true. I use  `cargo ws` command to create my workspace member packages. It is what generates these keys. 

```
[package]
name = "backlog"
edition = "2021"
description.workspace = true
readme.workspace = true
homepage.workspace = true
repository.workspace = true
keywords.workspace = true
rust-version.workspace = true
license.workspace = true
version.workspace = true
authors.workspace = true
include.workspace = true

[dependencies]
clap = { version = "4.5.7", features = ["derive"] }
core = { path = "../core" }
infra = { path = "../infra" }
tokio = { version = "1.38.0", features = ["full"] }

``` 

According to the [TOML v1 spec](https://toml.io/en/v1.0.0#keys) bare keys may only contain ASCII letters, ASCII digits, underscores, and dashes (A-Za-z0-9_-)

So the TOML parser is correct. 

I have submitted a PR with a regex to alleviate the exception in the extension.
